### PR TITLE
feat: add optional geoData property as alternative to geofile

### DIFF
--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -21,7 +21,7 @@ export class Geomap {
             /**
              * Contents of TopoJSON file. If specified, geofile is ignored.
              *
-             * @type {object|null}
+             * @type {Promise<object>|object|null}
              */
             geoData: null,
             height: null,
@@ -131,11 +131,12 @@ export class Geomap {
             self.update();
         };
 
-        if (self.properties.geoData) {
-            drawGeoData(self.properties.geoData);
-        } else {
-            d3JSONFetch(self.properties.geofile).then(geo => drawGeoData(geo));
-        }
+        Promise.resolve(() => {
+            if (self.properties.geoData) {
+                return self.properties.geoData;
+            }
+            return d3JSONFetch(self.properties.geofile);
+        }).then(geo => drawGeoData(geo));
     }
 
     update() {

--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -12,7 +12,18 @@ export class Geomap {
     constructor() {
         // Set default properties optimized for naturalEarth projection.
         this.properties = {
+            /**
+             * URL to TopoJSON file to load when geomap is drawn. Ignored if geoData is specified.
+             *
+             * @type {string|null}
+             */
             geofile: null,
+            /**
+             * Contents of TopoJSON file. If specified, geofile is ignored.
+             *
+             * @type {object|null}
+             */
+            geoData: null,
             height: null,
             postUpdate: null,
             projection: geoNaturalEarth1,
@@ -106,7 +117,7 @@ export class Geomap {
 
         self.path = geoPath().projection(proj);
 
-        d3JSONFetch(self.properties.geofile).then(geo => {
+        const drawGeoData = geo => {
             self.geo = geo;
             self.svg.append('g').attr('class', 'units zoom')
                 .selectAll('path')
@@ -118,7 +129,13 @@ export class Geomap {
                     .append('title')
                         .text(self.properties.unitTitle);
             self.update();
-        });
+        };
+
+        if (self.properties.geoData) {
+            drawGeoData(self.properties.geoData);
+        } else {
+            d3JSONFetch(self.properties.geofile).then(geo => drawGeoData(geo));
+        }
     }
 
     update() {

--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -131,12 +131,14 @@ export class Geomap {
             self.update();
         };
 
-        Promise.resolve(() => {
-            if (self.properties.geoData) {
-                return self.properties.geoData;
-            }
-            return d3JSONFetch(self.properties.geofile);
-        }).then(geo => drawGeoData(geo));
+        Promise.resolve()
+            .then(() => {
+                if (self.properties.geoData) {
+                    return self.properties.geoData;
+                }
+                return d3JSONFetch(self.properties.geofile);
+            })
+            .then(geo => drawGeoData(geo));
     }
 
     update() {


### PR DESCRIPTION
Hi again! 

We need to use `d3-geomap` in an environment where `fetch` is not available, and we already have the `TopoJSON` contents loaded on the page, so I've added the `geoData` key as an alternative to `geofile`.

You can pass the `TopoJSON` contents in directly to the `geoData` property. In doing so, the `geofile` property is ignored, and `fetch` becomes an optional dependency. No other functionality should be affected.

I also added some inline docs for clarity :)