### PR TITLE
remove white spaces from unit names

### DIFF
--- a/src/js/choropleth.js
+++ b/src/js/choropleth.js
@@ -49,7 +49,7 @@ export class Choropleth extends Geomap {
 
         // Add new fill styles based on data values.
         self.data.forEach((d) => {
-            let uid = d[self.properties.unitId].toString().trim().replace(/\s/g,''),
+            let uid = d[self.properties.unitId].toString().trim().replace(/ /g,'_'),
                 val = d[self.properties.column].toString().trim();
 
             // selectAll must be called and not just select, otherwise the data

--- a/src/js/choropleth.js
+++ b/src/js/choropleth.js
@@ -49,7 +49,7 @@ export class Choropleth extends Geomap {
 
         // Add new fill styles based on data values.
         self.data.forEach((d) => {
-            let uid = d[self.properties.unitId].toString().trim().replace(/ /g,'_'),
+            let uid = d[self.properties.unitId].toString().trim().replace(/\s/g,'_'),
                 val = d[self.properties.column].toString().trim();
 
             // selectAll must be called and not just select, otherwise the data

--- a/src/js/choropleth.js
+++ b/src/js/choropleth.js
@@ -49,7 +49,7 @@ export class Choropleth extends Geomap {
 
         // Add new fill styles based on data values.
         self.data.forEach((d) => {
-            let uid = d[self.properties.unitId].toString().trim(),
+            let uid = d[self.properties.unitId].toString().trim().replace(/\s/g,''),
                 val = d[self.properties.column].toString().trim();
 
             // selectAll must be called and not just select, otherwise the data

--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -123,7 +123,7 @@ export class Geomap {
                 .selectAll('path')
                 .data(topoFeature(geo, geo.objects[self.properties.units]).features)
                 .enter().append('path')
-                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId].replace(/ /g,'_')}`)
+                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId].replace(/\s/g,'_')}`)
                     .attr('d', self.path)
                     .on('click', self.clicked.bind(self))
                     .append('title')

--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -123,7 +123,7 @@ export class Geomap {
                 .selectAll('path')
                 .data(topoFeature(geo, geo.objects[self.properties.units]).features)
                 .enter().append('path')
-                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId].replace(/\s/g,'')}`)
+                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId].replace(/ /g,'_')}`)
                     .attr('d', self.path)
                     .on('click', self.clicked.bind(self))
                     .append('title')

--- a/src/js/geomap.js
+++ b/src/js/geomap.js
@@ -123,7 +123,7 @@ export class Geomap {
                 .selectAll('path')
                 .data(topoFeature(geo, geo.objects[self.properties.units]).features)
                 .enter().append('path')
-                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId]}`)
+                    .attr('class', (d) => `unit ${self.properties.unitPrefix}${d.properties[self.properties.unitId].replace(/\s/g,'')}`)
                     .attr('d', self.path)
                     .on('click', self.clicked.bind(self))
                     .append('title')


### PR DESCRIPTION
Removing white spaces makes it possible to use unit names. This makes it possible to use property "name" in topojson files instead of "fips" as discussed in issue #55.